### PR TITLE
Update ft.lua - add systemverilog

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -156,6 +156,7 @@ local L = setmetatable({
     typst = { M.cxx_l, M.cxx_b },
     v = { M.cxx_l, M.cxx_b },
     verilog = { M.cxx_l },
+    systemverilog = { M.cxx_l },
     vhdl = { M.dash },
     vim = { M.vim },
     vifm = { M.vim },


### PR DESCRIPTION
Systemverilog uses the same comment string as Verilog